### PR TITLE
add basic prod image multi stage build for backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build the application from source
+FROM golang:1.22-bullseye AS build-stage
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY ./server ./
+COPY ./.env.production ./.env.production
+COPY ./main.go ./main.go
+
+RUN GOOS=linux go build -ldflags="-X 'main.environment=production'" -o /go-web-service-production
+
+# Deploy the application binary into a lean image
+FROM debian:bullseye AS build-release-stage
+
+WORKDIR /
+
+COPY --from=build-stage /go-web-service-production /go-web-service-production
+COPY /.env.production /.env.production
+
+EXPOSE 8080
+
+ENTRYPOINT ["/go-web-service-production"]


### PR DESCRIPTION
Adds a Dockerfile for a multi stage build for a lean image containing only the executable for running the backend of the Go application